### PR TITLE
Added a missing thead tag

### DIFF
--- a/_docs/tables.html
+++ b/_docs/tables.html
@@ -12,7 +12,7 @@ meta: |
 <p>Beauter can create responsive tables having shaded rows and hover effects.</p>
 <strong>Example</strong>
 <pre><code>&lt;table class="_width100">
-  <thead>
+  &lt;thead>
     &lt;tr>
       &lt;th>Fruit&lt;/th>
       &lt;th>Count&lt;/th>


### PR DESCRIPTION
Somehow the thead tag does not display here: http://beauter.outboxcraft.com/docs/tables/ so I changed it from <thead> to &lt;thead>